### PR TITLE
Added basic text input search bar functionality

### DIFF
--- a/lib/search_page.dart
+++ b/lib/search_page.dart
@@ -9,10 +9,60 @@ class SearchPage extends StatefulWidget {
 }
 
 class _SearchPageState extends State<SearchPage> {
+
+  // Constructor for search page
   @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text('Search Page'),
-    );
+    return Scaffold(
+      
+      // App bar that has title for search page
+      appBar: AppBar(
+        title: const Text(
+          'Find Friends, Workouts, and Groups',
+          style: TextStyle(
+            fontFamily: 'Consolas',
+            fontSize: 20.0,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+
+      // Creates body that contains search bar
+      body: SearchAnchor(
+        builder: (BuildContext context, SearchController controller) {
+          return SearchBar(
+            controller: controller, // set controller as a search controller for the search bar
+
+            // Open search bar view if search bar is clicked or text is changed
+            onTap: () {
+              controller.openView();
+            },
+            onChanged: (_) {
+              controller.openView();
+            },
+
+            // adds search icon to bar
+            leading: const Icon(Icons.search),
+          );
+        }, 
+
+        // create suggestions for search bar
+        suggestionsBuilder: (BuildContext context, SearchController controller) {
+          // TODO: Currently unfinished with numbered items as placeholders
+          return List<ListTile>.generate(5, (int index) {
+            final String item = 'item $index';
+
+            // generate list tiles from items and if it is clicked, close view and update controller with item
+            return ListTile(
+              title: Text(item),
+              onTap: () {
+                setState(() {
+                  controller.closeView(item);
+                });
+              },
+            );
+          });
+        }),
+      );
   }
 }


### PR DESCRIPTION
Made it so that text can be inputted into a search bar widget on the search bar page. Search suggestions are offered (currently just placeholders) and when clicked fill the search bar and close the list view. No actual search functionality yet, just text input and UI.