### PR TITLE
add Makefile to build apk and ipa

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+all: android ios
+
+android: lib
+	flutter build apk --no-tree-shake-icons
+
+ios: lib
+	flutter build ipa --no-tree-shake-icons


### PR DESCRIPTION
The Makefile includes build targets for Android and iOS. The Android target builds an APK and the iOS target builds an IPA. These files are then uploaded to the website for download.

We should probably consider how to version the app.