### PR TITLE
Build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,9 @@ android: lib
 	flutter build apk --no-tree-shake-icons
 
 ios: lib
-	flutter build ipa --no-tree-shake-icons
+	flutter build ios --release --no-tree-shake-icons
+	mkdir build/ios/iphoneos/Payload
+	cp -r build/ios/iphoneos/Runner.app build/ios/iphoneos/Payload
+	cd build/ios/iphoneos
+	zip -r atlas.ipa Payload
+	cd ../../..

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+all: android ios
+
+android: lib
+	flutter build apk --no-tree-shake-icons
+
+ios: lib
+	flutter build ipa --no-tree-shake-icons


### PR DESCRIPTION
The Makefile now generates the a .ipa (instead of .app) when building for iOS.